### PR TITLE
Update train_image_count

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -10,7 +10,7 @@
   "hyp_ratio": 0.3333,
   "coordinates_range": [-10, 10],
   "test_image_count": 100,
-  "train_image_count": 15000,
+  "train_image_count": 12000,
   "image_size": [256, 256],
   "mask_type" : "random",
   "mask_color" : null,


### PR DESCRIPTION
example dataset is only 13233, while number is set to 15000. corrected to 12000.